### PR TITLE
Examples: Make daemon non interactive

### DIFF
--- a/examples/filesyncd/main.cpp
+++ b/examples/filesyncd/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char* argv[]) {
         auto cinMutex = std::make_shared<std::mutex>();
 
         syncer.setProtocol(ProtocolType::FTP);
-        syncer.setConflictResolveStrategy(ConflictResolveStrategy::Interactive);
+        syncer.setConflictResolveStrategy(ConflictResolveStrategy::LocalFirst);
         syncer.setSyncStrategy(SyncStrategy::Buffered);
 
         syncer.setServer(CmdLineArgs::server);


### PR DESCRIPTION
Interactive daemon makes no sense, since a daemon is usually started automatically.